### PR TITLE
Began ability to move objects

### DIFF
--- a/Assets/CodeMonkeyFree/Editor/ScriptableObjects/CodeMonkeyFreeSO.asset
+++ b/Assets/CodeMonkeyFree/Editor/ScriptableObjects/CodeMonkeyFreeSO.asset
@@ -14,47 +14,45 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   currentVersion: 1.01
   subtype: kitchenchaos
-  lastShownTimestamp: 1752813166
+  lastShownTimestamp: 1753380664
   lastUpdateResponse:
     version: 1.01
     versionUrl: https://unitycodemonkey.com
-  checkedLastUpdateTimestamp: 1752813166
+  checkedLastUpdateTimestamp: 1753380664
   lastQOTDResponse:
-    questionId: 202
-    questionText: 'What is the Color on the SpriteRenderer after running this code?
+    questionId: 204
+    questionText: 'What will be the value of isOne?
 
-      <p>Color
-      myColor = Color.red;</p>
+      <p>float oneThird = 1f
+      / 3f;</p>
 
-      <p>spriteRenderer.color = myColor;</p>
-
-      <p>myColor
-      = Color.blue;</p>'
-    answerA: Red
-    answerB: Blue
-    answerC: Don't Know
+      <p>bool isOne = (oneThird * 3f) == 1f;</p>'
+    answerA: true
+    answerB: false
+    answerC: 
     answerD: 
     answerE: 
-  lastQotdTimestamp: 1752813166
+  lastQotdTimestamp: 1753380664
   lastDynamicHeaderResponse:
     topImageUrl: https://codemonkeyexternal.blob.core.windows.net/external/Misc/summer2025CodeMonkeyBundle.png
     topText: All my Courses (and Games) in one Bundle! DEEP DISCOUNT ONLY THIS SUMMER!
     topLink: summer2025bundle
-    bottomText: AWESOME NEW Unity Bundle with Tools and Assets 97% OFF!
-    bottomLink: humblebundle
-  lastDynamicHeaderTimestamp: 1752813166
+    bottomText: Get my Code Monkey Toolkit and make games BETTER and FASTER! 50%
+      OFF right now!
+    bottomLink: toolkit
+  lastDynamicHeaderTimestamp: 1753380664
   websiteLatestMessage:
     text: <a href="https://cmonkey.co/freecourses">Check out all my FREE courses!
       Click here!</a>
-  websiteLatestMessageTimestamp: 1752813166
+  websiteLatestMessageTimestamp: 1753380664
   websiteLatestVideos:
     videos:
-    - youTubeId: PbFb7PFdT4A
-      title: Get 98% OFF on the Unity Summer Sale! (Awesome TOOLS and Assets!)
-    - youTubeId: 4kg2N-t2tWI
-      title: How REAL Developers Build Complex Games!
-    - youTubeId: OOVrtfWLdvE
-      title: TOP 10 FREE NEW Assets JULY 2025!
-    - youTubeId: ALogEuL6QdA
-      title: The BEST Design Patterns for Game Dev! (Save Time and make BETTER Games!)
-  websiteLatestVideosTimestamp: 1752813166
+    - youTubeId: SfZquiwnEPQ
+      title: TOP 10 NEW Systems and Tools JUNE 2025! | Unity Asset Store
+    - youTubeId: oBCXk_6Fft0
+      title: This MISTAKE cost $28,000,000!
+    - youTubeId: TYgEWbK-mCc
+      title: Learn C# by DOING, Hangman Beginner Project (Overview + Walkthrough)
+    - youTubeId: s9ORB4W5K2E
+      title: How to make an AWESOME Fantasy RPG in 19 MINUTES!
+  websiteLatestVideosTimestamp: 1753380664

--- a/Assets/Scenes/GameScene.unity
+++ b/Assets/Scenes/GameScene.unity
@@ -187,10 +187,20 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7475456560625919731, guid: e06f7a17347e89d4180c11df5b1716ca,
         type: 3}
+      propertyPath: testing
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7475456560625919731, guid: e06f7a17347e89d4180c11df5b1716ca,
+        type: 3}
       propertyPath: kitchenObjectSO
       value: 
       objectReference: {fileID: 11400000, guid: d89d57c651651d64b8971f58bd5e1ad3,
         type: 2}
+    - target: {fileID: 7475456560625919731, guid: e06f7a17347e89d4180c11df5b1716ca,
+        type: 3}
+      propertyPath: secondClearCounter
+      value: 
+      objectReference: {fileID: 630363080}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
@@ -606,6 +616,18 @@ MonoBehaviour:
   m_LightCookieSize: {x: 1, y: 1}
   m_LightCookieOffset: {x: 0, y: 0}
   m_SoftShadowQuality: 1
+--- !u!114 &630363080 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 7475456560625919731, guid: e06f7a17347e89d4180c11df5b1716ca,
+    type: 3}
+  m_PrefabInstance: {fileID: 407682482}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1e713b6edd8f5704e854430932f6ef94, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &692858044
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/ClearCounter.cs
+++ b/Assets/Scripts/ClearCounter.cs
@@ -6,11 +6,59 @@ public class ClearCounter : MonoBehaviour
 {
     [SerializeField] private KitchenObjectSO kitchenObjectSO;
     [SerializeField] private Transform counterTopPoint;
+    [SerializeField] private ClearCounter secondClearCounter;
+    [SerializeField] private bool testing;
+
+    private KitchenObject kitchenObject;
+
+
+    private void Update()
+    {
+        if (testing && Input.GetKeyDown(KeyCode.T))
+        {
+            if (kitchenObject != null)
+            {
+                kitchenObject.SetClearCounter(secondClearCounter); // Set the ClearCounter of the KitchenObject to the second ClearCounter
+            }
+        }
+    }
+
 
     public void Interact()
     {
-        Debug.Log("Interact!");
-        Transform kitchenObjectTransform = Instantiate(kitchenObjectSO.prefab, counterTopPoint); // Instantiate a tomato prefab at the counter top point
-        kitchenObjectTransform.localPosition = Vector3.zero; // Set the local position to zero so it appears at the counter top
+        if (kitchenObject == null)
+        {
+            Transform kitchenObjectTransform = Instantiate(kitchenObjectSO.prefab, counterTopPoint); // Instantiate a tomato prefab at the counter top point
+            kitchenObjectTransform.GetComponent<KitchenObject>().SetClearCounter(this); // Get the KitchenObject component from the instantiated prefab
+        }
+        else
+        {
+            Debug.Log(kitchenObject.GetClearCounter());
+        }
+    }
+
+    public Transform GetKitchenObjectFollowTransform()
+    {
+        return counterTopPoint; // Return the transform of the counter top point where the KitchenObject should follow
+    }
+
+    public void SetKitchenObject(KitchenObject _kitchenObject)
+    {
+        this.kitchenObject = _kitchenObject; // Set the KitchenObject associated with this ClearCounter
+    }
+
+    public KitchenObject GetKitchenObject()
+    {
+        return kitchenObject; // Return the KitchenObject associated with this ClearCounter
+    }
+
+    public void ClearKitchenObject()
+    {
+        kitchenObject = null; // Clear the KitchenObject associated with this ClearCounter
+    }
+
+    public bool HasKitchenObject()
+    {
+        return kitchenObject != null; // Check if this ClearCounter has a KitchenObject associated with it
     }
 }

--- a/Assets/Scripts/KitchenObject.cs
+++ b/Assets/Scripts/KitchenObject.cs
@@ -6,8 +6,34 @@ public class KitchenObject : MonoBehaviour
 {
     [SerializeField] private KitchenObjectSO kitchenObjectSO; // Reference to the ScriptableObject that holds data about this kitchen object
 
+    private ClearCounter clearCounter;
+
     public KitchenObjectSO GetKitchenObjectSO() // Method to get the ScriptableObject associated with this kitchen object
     {
         return kitchenObjectSO;
+    }
+
+    public void SetClearCounter(ClearCounter _clearCounter)
+    {
+        if (this.clearCounter != null)
+        {
+            this.clearCounter.ClearKitchenObject(); // If this kitchen object already has a ClearCounter, clear its reference
+        }
+
+        this.clearCounter = _clearCounter; // Method to set the ClearCounter that this kitchen object is associated with
+
+        if (clearCounter.HasKitchenObject())
+        {
+            Debug.LogError("ClearCounter already has a KitchenObject!"); // Log an error if the ClearCounter already has a kitchen object
+        }
+        _clearCounter.SetKitchenObject(this); // Set this kitchen object in the ClearCounter
+
+        transform.parent = _clearCounter.GetKitchenObjectFollowTransform(); // Set the parent of this kitchen object to the ClearCounter's follow transform
+        transform.localPosition = Vector3.zero; // Reset the local position to zero so it appears at the counter top
+    }
+
+    public ClearCounter GetClearCounter()
+    {
+        return clearCounter; // Method to get the ClearCounter associated with this kitchen object
     }
 }


### PR DESCRIPTION
Worked with parenting logic for KitchenObjects and ClearCounters.
- Objects can be moved from one counter to another
- multiple instances of an object do not exist on a counter without throwing an error
- Objects now take up counter space